### PR TITLE
Add PTB and Canary links.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,8 @@
                 <data android:scheme="http" />
                 <data android:host="discord.com" />
                 <data android:host="*.discord.com" />
+                <data android:host="ptb.discord.com" />
+                <data android:host="canary.discord.com" />
                 <data android:host="discordapp.com" />
                 <data android:host="*.discordapp.com" />
             </intent-filter>


### PR DESCRIPTION
This will fix an annoying "bug" where, instead of loading the page, it will open in the browser since Vendroid didn't open them by default. An example can be logging in on PTB/Canary branch. After typing your credentials and tapping Log In, the page will open in the browser.