### PR TITLE
add error callback when checking for updates

### DIFF
--- a/app/src/main/java/com/nin0dev/vendroid/MainActivity.kt
+++ b/app/src/main/java/com/nin0dev/vendroid/MainActivity.kt
@@ -54,7 +54,11 @@ class MainActivity : Activity() {
                             showDiscordToast("No updates available", "MESSAGE")
                         }
                     },
-                    { })
+                    { error ->
+                        e("Network error during update check", error)
+                        showDiscordToast("Failed to check for updates", "ERROR")
+                    }
+            )
             stringRequest.setShouldCache(false);
             queue.add(stringRequest)
         }

--- a/app/src/main/java/com/nin0dev/vendroid/MainActivity.kt
+++ b/app/src/main/java/com/nin0dev/vendroid/MainActivity.kt
@@ -55,8 +55,10 @@ class MainActivity : Activity() {
                         }
                     },
                     { error ->
-                        e("Network error during update check", error)
-                        showDiscordToast("Failed to check for updates", "ERROR")
+                        if (BuildConfig.DEBUG)  {
+                            e("Network error during update check", error)
+                        }
+                        Toast.makeText(this, "Failed to check for updates", Toast.LENGTH_SHORT).show()
                     }
             )
             stringRequest.setShouldCache(false);


### PR DESCRIPTION
when i tried to launch VE yesterday, it crashed. I figured github was down.
So i checked the source and added an error callback so when github is down or the updateTracker repo is down for some reason, you can still use the app 